### PR TITLE
Changes with respect to the JSON RPC 2.0 Protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,8 +114,9 @@
           method: 'wallet_invokeSnap', 
           params: [snapId, {
             method: 'storeAddress',
-            nameToStore: name, 
+            params : {nameToStore: name, 
             addressToStore: address
+            }
           }]
         })
         getAddresses()

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Montoya/address-book-snap-tutorial.git"
   },
   "source": {
-    "shasum": "zKdTkS9rn6P2r73G52WuMSxl6KyFNvt5mO2S+9EabvM=",
+    "shasum": "S82e+rhpUu68GjJOda7vCzP6ggAUnmlYF6E2mIXnnXs=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,8 @@ module.exports.onRpcRequest = async ({ origin, request }) => {
   switch (request.method) {
     case 'storeAddress': 
       state.book.push({
-        name:request.nameToStore,
-        address:request.addressToStore
+        name:request.params.nameToStore,
+        address:request.params.addressToStore
       });
       await wallet.request({
         method: 'snap_manageState', 


### PR DESCRIPTION
Now one does not get the error "Problem happened: Must specify a valid JSON-RPC request object as single parameter."
https://docs.metamask.io/guide/snaps-rpc-api.html#wallet-invokesnap